### PR TITLE
Update rebar.config.script

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -4,7 +4,6 @@ ExistingErlOpts = proplists:get_value(erl_opts, CONFIG, []),
 CONFIG1 =
   try
       persistent_term:info(),
-      io:format("CONFIG: enabling persistent_term support~n"),
       lists:keyreplace(erl_opts, 1, CONFIG,
 		       {erl_opts, [{d, 'HAVE_PERSISTENT_TERM'}|ExistingErlOpts]})
   catch


### PR DESCRIPTION
Suprisingly, removing this line fixes a critical bug with autocomplete in emacs, specifically with elixir + lsp + company mode.

This happens on M1 Mac and Android. This line is logged everytime eradius starts, which is annoying at best, but ends up prepending that line to every file saved from emacs (unless autocomplete is disabled).