### PR TITLE
[SIM-2584] Two secrets are stored under the same key

### DIFF
--- a/src/eradius_config.erl
+++ b/src/eradius_config.erl
@@ -103,6 +103,12 @@ validate_nas(NasId, IP, Secret, Name, undefined) ->
     validate_nas(NasId, IP, Secret, Name, validate_handler_nodes(Name));
 validate_nas(_NasId, IP, _Secret, Name, {invalid, _}) ->
     ?invalid("group ~p for nas ~p is undefined", [Name, IP]);
+validate_nas(NasId, IP, Secret = {Secret1, Secret2}, _Name, Nodes) when ?is_io(Secret1) andalso ?is_io(Secret2) andalso (?is_io(NasId) orelse NasId == undefined) ->
+    case is_list(IP) andalso string:tokens(IP, "/") of
+        [IP0, Mask] ->
+            [{NasId, validate_ip(IP1), validate_secret(Secret), Nodes} || IP1 <- generate_ip_list(validate_ip(IP0), Mask)];
+        _ -> {NasId, validate_ip(IP), validate_secret(Secret), Nodes}
+    end;
 validate_nas(NasId, IP, Secret, _Name, Nodes) when ?is_io(Secret) andalso (?is_io(NasId) orelse NasId == undefined) ->
     case is_list(IP) andalso string:tokens(IP, "/") of
         [IP0, Mask] ->

--- a/src/eradius_config.erl
+++ b/src/eradius_config.erl
@@ -202,7 +202,8 @@ validate_config(Config) ->
         [Server | _] ->
             case Server of
                 {List, SecondList} when is_list(List) and is_list(SecondList) ->
-                    validate_server_config(dedup_keys(Config));
+                    %% validate_server_config(dedup_keys(Config));
+                    validate_server_config(Config);
                 %% Check format of new command
                 {_Name, ServerConf} when is_tuple(ServerConf) ->
                     validate_new_config()

--- a/src/eradius_config.erl
+++ b/src/eradius_config.erl
@@ -202,8 +202,7 @@ validate_config(Config) ->
         [Server | _] ->
             case Server of
                 {List, SecondList} when is_list(List) and is_list(SecondList) ->
-                    %% validate_server_config(dedup_keys(Config));
-                    validate_server_config(Config);
+                    validate_server_config(dedup_keys(Config));
                 %% Check format of new command
                 {_Name, ServerConf} when is_tuple(ServerConf) ->
                     validate_new_config()
@@ -312,6 +311,8 @@ validate_secret(Secret) when is_list(Secret) ->
     unicode:characters_to_binary(Secret);
 validate_secret(Secret) when is_binary(Secret) ->
     Secret;
+validate_secret({Secret, Secret2}) when is_binary(Secret) and is_binary(Secret2) ->
+    {Secret, Secret2};
 validate_secret(OtherTerm) ->
     {invalid, io_lib:format("bad RADIUS secret: ~p", [OtherTerm])}.
 

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -128,6 +128,37 @@ handle_info(ReqUDP = {udp, Socket, FromIP, FromPortNo, Packet},
             State  = #state{name = ServerName, transacts = Transacts, ip = _IP, port = _Port}) ->
     TS1 = erlang:monotonic_time(),
     case lookup_nas(State, FromIP, Packet) of
+        {ok, ReqID, Handler, NasProp1, NasProp2} ->
+            #nas_prop{server_ip = ServerIP, server_port = Port} = NasProp1,
+            ReqKey = {FromIP, FromPortNo, ReqID},
+            NNasProp = NasProp#nas_prop{nas_port = FromPortNo},
+            eradius_counter:inc_counter(requests, NasProp1),
+
+            case ets:lookup(Transacts, ReqKey) of
+                [] ->
+                    HandlerPid = proc_lib:spawn_link(?MODULE, do_radius, [self(), ServerName, ReqKey, Handler, NNasProp1, ReqUDP, TS1]),
+                    HandlerPid = proc_lib:spawn_link(?MODULE, do_radius, [self(), ServerName, ReqKey, Handler, NNasProp2, ReqUDP, TS1]),
+
+                    ets:insert(Transacts, {ReqKey, {handling, HandlerPid}}),
+                    ets:insert(Transacts, {HandlerPid, ReqKey}),
+                    eradius_counter:inc_counter(pending, NasProp);
+
+                [{_ReqKey, {handling, HandlerPid}}] ->
+                    %% handler process is still working on the request
+                    ?LOG(debug, "~s From: ~s INF: Handler process ~p is still working on the request. duplicate request (being handled) ~p",
+                        [printable_peer(ServerIP, Port), printable_peer(FromIP, FromPortNo), HandlerPid, ReqKey]),
+                    eradius_counter:inc_counter(dupRequests, NasProp1);
+
+                [{_ReqKey, {replied, HandlerPid}}] ->
+                    %% handler process waiting for resend message
+                    HandlerPid ! {self(), resend, Socket},
+                    ?LOG(debug, "~s From: ~s INF: Handler ~p waiting for resent message. duplicate request (resent) ~p",
+                         [printable_peer(ServerIP, Port), printable_peer(FromIP, FromPortNo), HandlerPid, ReqKey]),
+                    eradius_counter:inc_counter(dupRequests, NasProp1),
+                    eradius_counter:inc_counter(retransmissions, NasProp1)
+            end,
+            NewState = State;
+
         {ok, ReqID, Handler, NasProp} ->
             #nas_prop{server_ip = ServerIP, server_port = Port} = NasProp,
             ReqKey = {FromIP, FromPortNo, ReqID},
@@ -201,6 +232,8 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 -spec lookup_nas(#state{}, inet:ip_address(), binary()) -> {ok, req_id(), eradius_server_mon:handler(), #nas_prop{}} | {discard, invalid | malformed}.
 lookup_nas(#state{ip = IP, port = Port}, NasIP, <<_Code, ReqID, _/binary>>) ->
     case eradius_server_mon:lookup_handler(IP, Port, NasIP) of
+        {ok, Handler, NasProp1, NasProp2} ->
+            {ok, ReqID, Handler, NasProp1, NasProp2};
         {ok, Handler, NasProp} ->
             {ok, ReqID, Handler, NasProp};
         {error, not_found} ->

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -131,7 +131,8 @@ handle_info(ReqUDP = {udp, Socket, FromIP, FromPortNo, Packet},
         {ok, ReqID, Handler, NasProp1, NasProp2} ->
             #nas_prop{server_ip = ServerIP, server_port = Port} = NasProp1,
             ReqKey = {FromIP, FromPortNo, ReqID},
-            NNasProp = NasProp#nas_prop{nas_port = FromPortNo},
+            NNasProp1 = NasProp1#nas_prop{nas_port = FromPortNo},
+            NNasProp2 = NasProp2#nas_prop{nas_port = FromPortNo},
             eradius_counter:inc_counter(requests, NasProp1),
 
             case ets:lookup(Transacts, ReqKey) of

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -295,6 +295,17 @@ run_remote_handler(Node, {HandlerMod, HandlerArgs}, NasProp, EncRequest) ->
 
 %% @private
 -spec handle_request(eradius_server_mon:handler(), #nas_prop{}, binary()) -> any().
+handle_request({HandlerMod, HandlerArg}, #nas_prop{secret = {Secret1, Secret2}, nas_ip = ServerIP, nas_port = Port}, EncRequest) ->
+    ?LOG(error, "299: ~s ~s", [Secret1, Secret2]),
+    case handle_request({HandlerMod, HandlerArg}, #nas_prop{secret = Secret1, nas_ip = ServerIP, nas_port = Port}, EncRequest) of
+        {discard, _} ->
+            ?LOG(error, "302"),
+            handle_request({HandlerMod, HandlerArg}, #nas_prop{secret = Secret2, nas_ip = ServerIP, nas_port = Port}, EncRequest);
+        other ->
+            ?LOG(error, "305"),
+            other
+    end;
+
 handle_request({HandlerMod, HandlerArg}, NasProp = #nas_prop{secret = Secret, nas_ip = ServerIP, nas_port = Port}, EncRequest) ->
     case eradius_lib:decode_request(EncRequest, Secret) of
         Request = #radius_request{} ->

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -142,7 +142,7 @@ handle_info(ReqUDP = {udp, Socket, FromIP, FromPortNo, Packet},
 
                     ets:insert(Transacts, {ReqKey, {handling, HandlerPid}}),
                     ets:insert(Transacts, {HandlerPid, ReqKey}),
-                    eradius_counter:inc_counter(pending, NasProp);
+                    eradius_counter:inc_counter(pending, NasProp1);
 
                 [{_ReqKey, {handling, HandlerPid}}] ->
                     %% handler process is still working on the request

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -296,14 +296,11 @@ run_remote_handler(Node, {HandlerMod, HandlerArgs}, NasProp, EncRequest) ->
 %% @private
 -spec handle_request(eradius_server_mon:handler(), #nas_prop{}, binary()) -> any().
 handle_request({HandlerMod, HandlerArg}, #nas_prop{secret = {Secret1, Secret2}, nas_ip = ServerIP, nas_port = Port}, EncRequest) ->
-    ?LOG(error, "299: ~s ~s", [Secret1, Secret2]),
     case handle_request({HandlerMod, HandlerArg}, #nas_prop{secret = Secret1, nas_ip = ServerIP, nas_port = Port}, EncRequest) of
         {discard, _} ->
-            ?LOG(error, "302"),
             handle_request({HandlerMod, HandlerArg}, #nas_prop{secret = Secret2, nas_ip = ServerIP, nas_port = Port}, EncRequest);
-        other ->
-            ?LOG(error, "305"),
-            other
+        Other ->
+            Other
     end;
 
 handle_request({HandlerMod, HandlerArg}, NasProp = #nas_prop{secret = Secret, nas_ip = ServerIP, nas_port = Port}, EncRequest) ->

--- a/src/eradius_server_mon.erl
+++ b/src/eradius_server_mon.erl
@@ -55,7 +55,7 @@ lookup_handler(IP, Port, NasIP) ->
         [Rec1, Rec2] ->
             Prop1 = (Rec1#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
             Prop2 = (Rec2#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
-            {ok, Rec#nas.handler, Prop1, Prop2};
+            {ok, Rec1#nas.handler, Prop1, Prop2};
         [Rec] ->
             Prop = (Rec#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
             {ok, Rec#nas.handler, Prop}

--- a/src/eradius_server_mon.erl
+++ b/src/eradius_server_mon.erl
@@ -52,6 +52,10 @@ lookup_handler(IP, Port, NasIP) ->
             {error, not_found};
         [] ->
             lookup_handler(IP, Port, {0, 0, 0, 0});
+        [Rec1, Rec2] ->
+            Prop1 = (Rec1#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
+            Prop2 = (Rec2#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
+            {ok, Rec#nas.handler, Prop1, Prop2}
         [Rec] ->
             Prop = (Rec#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
             {ok, Rec#nas.handler, Prop}

--- a/src/eradius_server_mon.erl
+++ b/src/eradius_server_mon.erl
@@ -55,7 +55,7 @@ lookup_handler(IP, Port, NasIP) ->
         [Rec1, Rec2] ->
             Prop1 = (Rec1#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
             Prop2 = (Rec2#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
-            {ok, Rec#nas.handler, Prop1, Prop2}
+            {ok, Rec#nas.handler, Prop1, Prop2};
         [Rec] ->
             Prop = (Rec#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
             {ok, Rec#nas.handler, Prop}

--- a/src/eradius_server_mon.erl
+++ b/src/eradius_server_mon.erl
@@ -52,10 +52,6 @@ lookup_handler(IP, Port, NasIP) ->
             {error, not_found};
         [] ->
             lookup_handler(IP, Port, {0, 0, 0, 0});
-        [Rec1, Rec2] ->
-            Prop1 = (Rec1#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
-            Prop2 = (Rec2#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
-            {ok, Rec1#nas.handler, Prop1, Prop2};
         [Rec] ->
             Prop = (Rec#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
             {ok, Rec#nas.handler, Prop}

--- a/src/eradius_server_mon.erl
+++ b/src/eradius_server_mon.erl
@@ -115,6 +115,7 @@ configure(#state{running = Running}) ->
             ?LOG(error, "Invalid server config, ~s", [Message]),
             {error, invalid_config};
         ServList -> %% list of {ServerName, ServerAddr, NasHandler} tuples
+            ?LOG(error, "serve_list, ~s", [ServList]),
             NasList = lists:flatmap(fun(Server) -> server_naslist(Server) end, ServList),
             Tab = ets:tab2list(?NAS_TAB),
             ToDelete = Tab -- NasList,

--- a/src/eradius_server_mon.erl
+++ b/src/eradius_server_mon.erl
@@ -115,7 +115,6 @@ configure(#state{running = Running}) ->
             ?LOG(error, "Invalid server config, ~s", [Message]),
             {error, invalid_config};
         ServList -> %% list of {ServerName, ServerAddr, NasHandler} tuples
-            ?LOG(error, "serve_list, ~s", [ServList]),
             NasList = lists:flatmap(fun(Server) -> server_naslist(Server) end, ServList),
             Tab = ets:tab2list(?NAS_TAB),
             ToDelete = Tab -- NasList,


### PR DESCRIPTION
https://flickswitch.atlassian.net/browse/SIM-2583

<details>
  <summary><h3>First Attempt</h3></summary>

The credentials table used to only pick up the last secret in the case below:

```elixir
config :eradius,
  radius_callback: Radius.AlwaysAck,
  root: [
    {{Radius.AlwaysAck, 'root', []}, [{'127.0.0.1', "secret"}]},
    {{Radius.AlwaysAck, 'root', []}, [{'127.0.0.1', "secret2"}]}
  ]
```

The change in `src/eradius_server_mon.erl` creates _two_ `#nas_prop{}` records and the change in `src/eradius_server.erl` then takes the two records and spawns two handler processes (one should always fail).

</details>

<h3>Second Attempt</h3>

```elixir
config :eradius,
  radius_callback: Radius.AlwaysAck,
  root: [
    {{Radius.AlwaysAck, 'root', []}, [{'127.0.0.1', {"secret", "secret2"}}]}
  ]
```

Demo (switching secrets between "secret" and "secret2" after `recompile` call.

```elixir
iex(4)> Radius.Dev.Client.accounting_start
{:radius_request, 0, :accresp, [], "secret",
 <<41, 48, 187, 184, 153, 37, 65, 15, 31, 179, 209, 155, 5, 88, 215, 162>>,
 false, ""}
iex(5)> recompile
Compiling 1 file (.ex)
:ok
iex(6)> Radius.Dev.Client.accounting_start
{:radius_request, 1, :accresp, [], "secret2",
 <<197, 40, 201, 123, 220, 151, 131, 132, 99, 233, 211, 48, 29, 217, 116, 99>>,
 false, ""}
```

- Change `src/eradius_config.erl` to validate two-element tuple passwords.
- Pattern match in `handle_request/3` in `src/eradius_server.erl` for tuple passwords, then try the passwords in two seperate calls to the real `handle_request` function.