### PR TITLE
add telemetry hooks to inc, dec, and observe

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,6 +32,8 @@
     rebar3_hex]
 }.
 
+{deps, [{telemetry, "~> 1.0"}]}.
+
 %% == Cover covervalls.io ==
 {cover_enabled, true}.
 {cover_export_enabled, true}.

--- a/src/eradius_counter.erl
+++ b/src/eradius_counter.erl
@@ -108,6 +108,10 @@ aggregate({Servers, {ResetTS, Nass}}) ->
 %% @doc Set Value for the given prometheus boolean metric by the given Name with
 %% the given values
 set_boolean_metric(Name, Labels, Value) ->
+    Events = [eradius, boolean, Name],
+    Measurements = #{value => Value},
+    Metadata = #{labels => Labels},
+    telemetry:execute(Events, Measurements, Metadata),
     case code:is_loaded(prometheus) of
         {file, _} ->
             try


### PR DESCRIPTION
I found that eradius_counter.erl already has function calls in all the places we need in eradius_server (and eradius_client), so this ends up being a four line change.

In eradius_counter.erl: There are some call sites that I avoided adding triggers to, since there is insufficient metadata to attach to the events. They end up calling into a gen_server with better metadata, which should have the triggers.

I just picked `[eradius, inc_counter]` as an arbitrary prefix for events.

I ended up not using `:telemetry.span`, since eradius already does a monotonic_time comparison.

Demo module that hooks into the telemetry triggers:

```elixir
defmodule Ocs.Telemetry do
  @moduledoc "A basic telemetry handler"

  @server_durations ~w[
    eradius_request_duration_milliseconds
    eradius_access_request_duration_milliseconds
    eradius_request_duration_milliseconds
    eradius_accounting_request_duration_milliseconds
    eradius_request_duration_milliseconds
    eradius_coa_request_duration_milliseconds
    eradius_request_duration_milliseconds
    eradius_disconnect_request_duration_milliseconds
  ]a

  @client_durations ~w[
    eradius_client_request_duration_milliseconds
    eradius_client_access_request_duration_milliseconds
    eradius_client_accounting_request_duration_milliseconds
    eradius_client_coa_request_duration_milliseconds
    eradius_client_disconnect_request_duration_milliseconds
  ]a

  @server_only_counters ~w[
    invalidRequests
    discardNoHandler
  ]a

  def handle_event([:eradius, :observe, label], %{value: value}, metadata, config) do
    # histogram in prometheus:
    IO.puts("eradius observe label:#{label}")
    IO.puts("value #{inspect value}")
    IO.puts("metadata #{inspect metadata}")
    IO.puts("config #{inspect config}")
  end

  # only in eradius_client:
  def handle_event([:eradius, :boolean, :server_status], %{value: value}, metadata, config) do
    IO.puts("eradius boolean server_status")
    IO.puts("value #{inspect value}")
    IO.puts("metadata #{inspect metadata}")
    IO.puts("config #{inspect config}")
  end

  def handle_event([:eradius, :inc_counter, :pending], %{value: value}, metadata, config) do
    # pending is a count of in-flight requests
    IO.puts("eradius inc_counter pending")
    IO.puts("value #{inspect value}")
    IO.puts("metadata #{inspect metadata}")
    IO.puts("config #{inspect config}")
  end

  def handle_event([:eradius, :dec_counter, :pending], %{value: value}, metadata, config) do
    # decrement pending (the only value that ever gets decremented)
    IO.puts("eradius dec_counter pending")
    IO.puts("value #{inspect value}")
    IO.puts("metadata #{inspect metadata}")
    IO.puts("config #{inspect config}")
  end

  @server_counters ~w[
    badAuthenticators
    dupRequests
    dupRequests
    malformedRequests
    packetsDropped
    replies
    requests
    retransmissions
    unknownTypes
  ]a

  @client_counters ~w[
    requests
    replies
    retransmissions
    accept
    accessRequests
    bad_authenticator
    challenge
    coaRequests
    coaack
    coanak
    discRequests
    discack
    discnak
    dropped
    reject
    timeouts
    unknown_req_type
  ]a

  def handle_event([:eradius, :inc_counter, counter], %{value: value}, metadata, config) do
    IO.puts("eradius increment counter:#{counter}")
    IO.puts("value #{inspect value}")
    IO.puts("metadata #{inspect metadata}")
    IO.puts("config #{inspect config}")
  end
end
```

This still needs an attach call to activate. Something like this works: `:telemetry.attach( "log-response-handler", [:ocs, :radius, :ping], &__MODULE__.handle_event/4, nil);`